### PR TITLE
Add basic FastAPI backend and React Native frontend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# FastAPI Backend
+
+This backend exposes a single endpoint to fetch dating cards.
+
+## Running
+
+Install dependencies and run the server:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+The server will be available at `http://localhost:8000`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class Card(BaseModel):
+    id: int
+    name: str
+    age: int
+    bio: str
+
+FAKE_CARDS = [
+    {"id": 1, "name": "Alice", "age": 25, "bio": "Loves hiking and coffee."},
+    {"id": 2, "name": "Bob", "age": 30, "bio": "Adventurous and fun."},
+]
+
+@app.get("/cards", response_model=list[Card])
+async def get_cards():
+    return FAKE_CARDS

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+
+export default function App() {
+  const [cards, setCards] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/cards')
+      .then((response) => response.json())
+      .then(setCards)
+      .catch((error) => console.error('Error fetching cards', error));
+  }, []);
+
+  const renderItem = ({ item }) => (
+    <View style={styles.card}>
+      <Text style={styles.name}>{`${item.name}, ${item.age}`}</Text>
+      <Text>{item.bio}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={cards}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderItem}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  card: {
+    marginVertical: 8,
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,14 @@
+# React Native Frontend
+
+This simple React Native application fetches cards from the FastAPI backend and displays them in a list.
+
+## Running
+
+Install dependencies with npm or yarn, then run the app via Expo or React Native CLI:
+
+```bash
+npm install
+npx expo start
+```
+
+Ensure the backend is running on `http://localhost:8000`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dating-cards-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.72.4"
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple FastAPI backend with `/cards` endpoint
- add React Native frontend that fetches cards and displays them
- document running instructions for each component

## Testing
- `python3 -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688320d420b4833198ce26bc8f5c752d